### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ env:
 jobs:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=debian_max
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=debian_min
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=ubuntu_max
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=ubuntu_min
     - env:
         - MOLECULEW_ANSIBLE=2.9.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ user-friendly alternative to `find`.
 Requirements
 ------------
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.